### PR TITLE
Need to include numpy directory in order to access numpy functions in C

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ from distutils.core import setup
 from distutils.extension import Extension
 from Cython.Distutils import build_ext
 import Cython.Compiler.Options as o
+import numpy as np
 
 o.annotate = True
 
@@ -18,6 +19,7 @@ ext_modules = [
 setup(
   name='Limit cycle search',
   cmdclass={'build_ext': build_ext},
-  ext_modules=ext_modules
+  ext_modules=ext_modules,
+  include_dirs=[np.get_include()]
 )
 


### PR DESCRIPTION
Was getting this error when I ran `python setup.py build_ext --inplace`:

src/integrator.c:687:10: fatal error: 'numpy/arrayobject.h' file not found
#include "numpy/arrayobject.h"
         ^~~~~~~~~~~~~~~~~~~~~
1 error generated.

This edit fixed it.